### PR TITLE
Add 'response' event type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ var internals = {
 
 internals.createEventMap = function (events) {
 
-	var eventTypes = ['error', 'ops', 'request', 'log'];
+	var eventTypes = ['error', 'ops', 'request', 'response', 'log'];
 	var result = {};
 
 	eventTypes.forEach(function (event) {


### PR DESCRIPTION
Good supports now both 'request' and 'response' event types, the latter one was missing here.